### PR TITLE
Switch to React Router for page navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "lucide-react": "^0.525.0",
+    "react-router-dom": "^6.23.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -1,20 +1,15 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import LandingPage from './pages/LandingPage';
 import LocationsPage from './pages/LocationsPage';
 
-const App = () => {
-    const [pageState, setPageState] = useState({ page: 'landing', filters: [] });
+const LocationsWrapper = () => {
+    const location = useLocation();
+    const filters = location.state?.filters || [];
+    return <LocationsPage initialFilters={filters} />;
+};
 
-    const renderPage = () => {
-        switch (pageState.page) {
-            case 'landing': 
-                return <LandingPage setPageState={setPageState} />;
-            case 'locations': 
-                return <LocationsPage setPageState={setPageState} initialFilters={pageState.filters} />;
-            default: 
-                return <LandingPage setPageState={setPageState} />;
-        }
-    };
+const App = () => {
 
     const GlobalStyles = () => (
         <style jsx global>{`
@@ -26,10 +21,16 @@ const App = () => {
     );
 
     return (
-        <main style={{ fontFamily: "'Nunito', sans-serif" }}>
-            <GlobalStyles />
-            {renderPage()}
-        </main>
+        <BrowserRouter>
+            <main style={{ fontFamily: "'Nunito', sans-serif" }}>
+                <GlobalStyles />
+                <Routes>
+                    <Route path="/" element={<LandingPage />} />
+                    <Route path="/locations" element={<LocationsWrapper />} />
+                    <Route path="*" element={<LandingPage />} />
+                </Routes>
+            </main>
+        </BrowserRouter>
     );
 };
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders landing page', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Hallo Noord-Holland!/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -1,25 +1,12 @@
 import React from 'react';
 import { ArrowRight } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { doenData } from '../data/doen';
 import { etenData } from '../data/eten';
 
-const LandingPage = ({ setPageState }) => {
-
-    const handleDoenClick = () => {
-        const doenCategories = [...new Set(doenData.map(item => item.categorie))];
-        setPageState({
-            page: 'locations',
-            filters: doenCategories
-        });
-    };
-
-    const handleEtenClick = () => {
-        const etenCategories = [...new Set(etenData.map(item => item.categorie))];
-        setPageState({
-            page: 'locations',
-            filters: etenCategories
-        });
-    };
+const LandingPage = () => {
+    const doenCategories = [...new Set(doenData.map(item => item.categorie))];
+    const etenCategories = [...new Set(etenData.map(item => item.categorie))];
 
     return (
         <div className="min-h-screen bg-amber-50">
@@ -35,8 +22,9 @@ const LandingPage = ({ setPageState }) => {
                 </div>
 
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-                    <div 
-                        onClick={handleDoenClick}
+                    <Link
+                        to="/locations"
+                        state={{ filters: doenCategories }}
                         className="group bg-white p-6 rounded-2xl shadow-lg hover:shadow-xl transform hover:-translate-y-1 transition-all duration-300 cursor-pointer"
                     >
                         <div className="text-4xl mb-3">🎡</div>
@@ -50,10 +38,11 @@ const LandingPage = ({ setPageState }) => {
                             <span>Verken activiteiten</span>
                             <ArrowRight className="w-4 h-4 ml-2 transform group-hover:translate-x-1 transition-transform" />
                         </div>
-                    </div>
+                    </Link>
 
-                    <div 
-                        onClick={handleEtenClick}
+                    <Link
+                        to="/locations"
+                        state={{ filters: etenCategories }}
                         className="group bg-white p-6 rounded-2xl shadow-lg hover:shadow-xl transform hover:-translate-y-1 transition-all duration-300 cursor-pointer"
                     >
                         <div className="text-4xl mb-3">🍔</div>
@@ -67,7 +56,7 @@ const LandingPage = ({ setPageState }) => {
                             <span>Ontdek de smaken</span>
                             <ArrowRight className="w-4 h-4 ml-2 transform group-hover:translate-x-1 transition-transform" />
                         </div>
-                    </div>
+                    </Link>
 
                     <div className="group bg-white p-6 rounded-2xl shadow-lg hover:shadow-xl transform hover:-translate-y-1 transition-all duration-300 cursor-not-allowed opacity-70">
                         <div className="text-4xl mb-3">☀️</div>

--- a/src/pages/LocationsPage.js
+++ b/src/pages/LocationsPage.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { ArrowRight } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
 import SearchAndFilter from '../components/SearchAndFilter';
 import LocationCard from '../components/LocationCard';
@@ -9,7 +10,7 @@ import { useFilteredLocations } from '../hooks/useFilteredLocations';
 import { useHiddenLocations } from '../hooks/useHiddenLocations';
 import { locaties } from '../data/index';
 
-const LocationsPage = ({ setPageState, initialFilters }) => {
+const LocationsPage = ({ initialFilters }) => {
     const [searchTerm, setSearchTerm] = useState('');
     const [selectedCategories, setSelectedCategories] = useState(initialFilters || []);
     const [selectedLocation, setSelectedLocation] = useState(null);
@@ -48,10 +49,10 @@ const LocationsPage = ({ setPageState, initialFilters }) => {
     return (
         <div className="min-h-screen bg-amber-100/50">
              <div className="fixed top-4 left-4 z-30">
-                <button onClick={() => setPageState({ page: 'landing' })} className="flex items-center gap-2 px-4 py-2 bg-white/80 backdrop-blur-sm text-slate-700 rounded-full shadow-lg hover:bg-white transition-colors">
+                <Link to="/" className="flex items-center gap-2 px-4 py-2 bg-white/80 backdrop-blur-sm text-slate-700 rounded-full shadow-lg hover:bg-white transition-colors">
                     <ArrowRight className="w-4 h-4 transform rotate-180" />
                     <span>Home</span>
-                </button>
+                </Link>
             </div>
             <div className="container mx-auto p-4 md:p-8">
                 <PageHeader

--- a/src/pages/LocationsPage.test.js
+++ b/src/pages/LocationsPage.test.js
@@ -2,13 +2,18 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LocationsPage from './LocationsPage';
 import { locaties } from '../data';
+import { MemoryRouter } from 'react-router-dom';
 
 beforeEach(() => {
     window.localStorage.clear();
 });
 
 test('hidden locations are removed and can be restored', async () => {
-    render(<LocationsPage setPageState={() => {}} initialFilters={[]} />);
+    render(
+        <MemoryRouter>
+            <LocationsPage initialFilters={[]} />
+        </MemoryRouter>
+    );
     const name = locaties[0].naam;
 
     // Card should be visible initially
@@ -24,3 +29,4 @@ test('hidden locations are removed and can be restored', async () => {
     userEvent.click(screen.getByText('Verborgen herstellen'));
     expect(await screen.findByText(name)).toBeInTheDocument();
 });
+


### PR DESCRIPTION
## Summary
- install `react-router-dom` dependency
- use `<BrowserRouter>` and `<Route>` for navigation
- update landing page cards to be `<Link>`s
- replace home button with `<Link>`
- update tests for new routing

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68822ed6593883248f69991aef64066c