### PR TITLE
Add favorites and hidden location contexts

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import LandingPage from './pages/LandingPage';
 import LocationsPage from './pages/LocationsPage';
+import { FavoritesProvider } from './context/FavoritesContext';
+import { HiddenLocationsProvider } from './context/HiddenLocationsContext';
 
 const App = () => {
     const [pageState, setPageState] = useState({ page: 'landing', filters: [] });
@@ -26,10 +28,14 @@ const App = () => {
     );
 
     return (
-        <main style={{ fontFamily: "'Nunito', sans-serif" }}>
-            <GlobalStyles />
-            {renderPage()}
-        </main>
+        <FavoritesProvider>
+            <HiddenLocationsProvider>
+                <main style={{ fontFamily: "'Nunito', sans-serif" }}>
+                    <GlobalStyles />
+                    {renderPage()}
+                </main>
+            </HiddenLocationsProvider>
+        </FavoritesProvider>
     );
 };
 

--- a/src/components/LocationCard.js
+++ b/src/components/LocationCard.js
@@ -1,35 +1,42 @@
 import React from 'react';
 import { Euro, Heart } from 'lucide-react';
 import { getCategoryStyle } from '../data/utils';
+import { useFavorites } from '../hooks/useFavorites';
 
-const LocationCard = ({ location, isFavorite, onToggleFavorite, onShowDetails }) => (
-    <div className="bg-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 group flex flex-col">
-        <div className="relative">
-            <div onClick={() => onShowDetails(location)} className="cursor-pointer">
-                <img src={location.image} alt={location.naam} className="w-full h-48 object-cover rounded-t-2xl" />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"></div>
-                 <h3 className="absolute bottom-3 left-4 text-xl font-bold text-white drop-shadow-md">{location.naam}</h3>
-            </div>
-            <div className={`absolute top-3 left-3 px-3 py-1 rounded-full text-xs font-bold border ${getCategoryStyle(location.categorie)}`}>
-                {location.categorie}
-            </div>
-            <button onClick={() => onToggleFavorite(location.naam)} className="absolute top-3 right-3 p-2 bg-white/70 backdrop-blur-sm rounded-full text-rose-500 hover:bg-white transition-colors">
-                <Heart className={`w-6 h-6 transition-all ${isFavorite ? 'fill-current' : 'stroke-current'}`} />
-            </button>
-        </div>
-        <div className="p-5 flex flex-col flex-grow">
-            <p className="text-sm text-slate-600 mb-4 line-clamp-3 flex-grow">{location.beschrijving}</p>
-            <div className="flex justify-between items-center border-t border-slate-200 pt-4 mt-auto">
-                <div className="flex items-center gap-2 text-sm text-emerald-700 font-semibold">
-                    <Euro className="w-5 h-5" />
-                    <span>{location.prijsindicatie.split(',')[0]}</span>
+const LocationCard = ({ location, onShowDetails }) => {
+    const { favorites, toggleFavorite } = useFavorites();
+    const isFavorite = favorites.has(location.naam);
+
+    return (
+        <div className="bg-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 group flex flex-col">
+            <div className="relative">
+                <div onClick={() => onShowDetails(location)} className="cursor-pointer">
+                    <img src={location.image} alt={location.naam} className="w-full h-48 object-cover rounded-t-2xl" />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"></div>
+                    <h3 className="absolute bottom-3 left-4 text-xl font-bold text-white drop-shadow-md">{location.naam}</h3>
                 </div>
-                <button onClick={() => onShowDetails(location)} className="text-amber-800 font-semibold hover:text-rose-600 transition-colors text-sm">
-                    Meer info →
+                <div className={`absolute top-3 left-3 px-3 py-1 rounded-full text-xs font-bold border ${getCategoryStyle(location.categorie)}`}>
+                    {location.categorie}
+                </div>
+                <button onClick={() => toggleFavorite(location.naam)} className="absolute top-3 right-3 p-2 bg-white/70 backdrop-blur-sm rounded-full text-rose-500 hover:bg-white transition-colors">
+                    <Heart className={`w-6 h-6 transition-all ${isFavorite ? 'fill-current' : 'stroke-current'}`} />
                 </button>
             </div>
+            <div className="p-5 flex flex-col flex-grow">
+                <p className="text-sm text-slate-600 mb-4 line-clamp-3 flex-grow">{location.beschrijving}</p>
+                <div className="flex justify-between items-center border-t border-slate-200 pt-4 mt-auto">
+                    <div className="flex items-center gap-2 text-sm text-emerald-700 font-semibold">
+                        <Euro className="w-5 h-5" />
+                        <span>{location.prijsindicatie.split(',')[0]}</span>
+                    </div>
+                    <button onClick={() => onShowDetails(location)} className="text-amber-800 font-semibold hover:text-rose-600 transition-colors text-sm">
+                        Meer info →
+                    </button>
+                </div>
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 export default LocationCard;
+

--- a/src/components/LocationModal.js
+++ b/src/components/LocationModal.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import { MapPin, Clock, Globe, Euro, Heart, X } from 'lucide-react';
 import { getCategoryStyle, getGoogleMapsUrl } from '../data/utils';
+import { useFavorites } from '../hooks/useFavorites';
+import { useHiddenLocations } from '../hooks/useHiddenLocations';
 
-const LocationModal = ({ location, isFavorite, onClose, onToggleFavorite, onHideLocation }) => {
+const LocationModal = ({ location, onClose }) => {
+    const { favorites, toggleFavorite } = useFavorites();
+    const { hideLocation } = useHiddenLocations();
+    const isFavorite = location ? favorites.has(location.naam) : false;
     // Render niets als er geen locatie is geselecteerd
     if (!location) return null;
 
@@ -69,14 +74,14 @@ const LocationModal = ({ location, isFavorite, onClose, onToggleFavorite, onHide
                     {/* Knoppen voor acties */}
                     <div className="flex flex-wrap gap-3 pt-4 border-t border-amber-200">
                         <button
-                            onClick={() => onToggleFavorite(location.naam)}
+                            onClick={() => toggleFavorite(location.naam)}
                             className={`flex items-center gap-2 px-4 py-2 rounded-full font-semibold transition-colors ${ isFavorite ? 'bg-rose-500 text-white' : 'bg-white border-2 border-slate-200 text-slate-700 hover:bg-rose-50' }`}
                         >
                             <Heart className={`w-5 h-5 ${isFavorite ? 'fill-current' : ''}`} />
                             {isFavorite ? 'Opgeslagen!' : 'Opslaan'}
                         </button>
                         <button
-                            onClick={() => { onHideLocation(location.naam); onClose(); }}
+                            onClick={() => { hideLocation(location.naam); onClose(); }}
                             className="px-4 py-2 rounded-full font-semibold bg-white border-2 border-slate-200 text-slate-700 hover:bg-slate-50 transition-colors"
                         >
                             Verberg

--- a/src/context/FavoritesContext.js
+++ b/src/context/FavoritesContext.js
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useState, useMemo } from 'react';
+import { locaties } from '../data';
+
+const FavoritesContext = createContext();
+
+export const FavoritesProvider = ({ children }) => {
+    const [favorites, setFavorites] = useState(new Set());
+
+    const toggleFavorite = (locationName) => {
+        setFavorites(prev => {
+            const newSet = new Set(prev);
+            newSet.has(locationName) ? newSet.delete(locationName) : newSet.add(locationName);
+            return newSet;
+        });
+    };
+
+    const favoriteLocations = useMemo(() => {
+        return locaties.filter(location => favorites.has(location.naam));
+    }, [favorites]);
+
+    const value = { favorites, favoriteLocations, toggleFavorite };
+
+    return (
+        <FavoritesContext.Provider value={value}>
+            {children}
+        </FavoritesContext.Provider>
+    );
+};
+
+export const useFavorites = () => {
+    return useContext(FavoritesContext);
+};

--- a/src/context/HiddenLocationsContext.js
+++ b/src/context/HiddenLocationsContext.js
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+const STORAGE_KEY = 'hiddenLocations';
+const HiddenLocationsContext = createContext();
+
+export const HiddenLocationsProvider = ({ children }) => {
+    const [hidden, setHidden] = useState(() => {
+        if (typeof window === 'undefined') return new Set();
+        const stored = localStorage.getItem(STORAGE_KEY);
+        return stored ? new Set(JSON.parse(stored)) : new Set();
+    });
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        localStorage.setItem(STORAGE_KEY, JSON.stringify([...hidden]));
+    }, [hidden]);
+
+    const hideLocation = (name) => {
+        setHidden(prev => new Set(prev).add(name));
+    };
+
+    const restoreLocation = (name) => {
+        setHidden(prev => {
+            const newSet = new Set(prev);
+            newSet.delete(name);
+            return newSet;
+        });
+    };
+
+    return (
+        <HiddenLocationsContext.Provider value={{ hidden, hideLocation, restoreLocation }}>
+            {children}
+        </HiddenLocationsContext.Provider>
+    );
+};
+
+export const useHiddenLocations = () => {
+    return useContext(HiddenLocationsContext);
+};

--- a/src/hooks/useFavorites.js
+++ b/src/hooks/useFavorites.js
@@ -1,18 +1,6 @@
-import { useState, useMemo } from 'react';
-import { locaties } from '../data/index';
+import { useContext } from 'react';
+import { FavoritesContext } from '../context/FavoritesContext';
 
 export const useFavorites = () => {
-    const [favorites, setFavorites] = useState(new Set());
-
-    const toggleFavorite = (locationName) => {
-        const newFavorites = new Set(favorites);
-        newFavorites.has(locationName) ? newFavorites.delete(locationName) : newFavorites.add(locationName);
-        setFavorites(newFavorites);
-    };
-
-    const favoriteLocations = useMemo(() => {
-        return locaties.filter(location => favorites.has(location.naam));
-    }, [favorites]);
-
-    return { favorites, favoriteLocations, toggleFavorite };
+    return useContext(FavoritesContext);
 };

--- a/src/hooks/useHiddenLocations.js
+++ b/src/hooks/useHiddenLocations.js
@@ -1,30 +1,6 @@
-import { useState, useEffect } from 'react';
-
-const STORAGE_KEY = 'hiddenLocations';
+import { useContext } from 'react';
+import { HiddenLocationsContext } from '../context/HiddenLocationsContext';
 
 export const useHiddenLocations = () => {
-    const [hidden, setHidden] = useState(() => {
-        if (typeof window === 'undefined') return new Set();
-        const stored = localStorage.getItem(STORAGE_KEY);
-        return stored ? new Set(JSON.parse(stored)) : new Set();
-    });
-
-    useEffect(() => {
-        if (typeof window === 'undefined') return;
-        localStorage.setItem(STORAGE_KEY, JSON.stringify([...hidden]));
-    }, [hidden]);
-
-    const hideLocation = (name) => {
-        setHidden(prev => new Set(prev).add(name));
-    };
-
-    const restoreLocation = (name) => {
-        setHidden(prev => {
-            const newSet = new Set(prev);
-            newSet.delete(name);
-            return newSet;
-        });
-    };
-
-    return { hidden, hideLocation, restoreLocation };
+    return useContext(HiddenLocationsContext);
 };

--- a/src/pages/LocationsPage.js
+++ b/src/pages/LocationsPage.js
@@ -77,8 +77,6 @@ const LocationsPage = ({ setPageState, initialFilters }) => {
                         <LocationCard
                             key={location.naam}
                             location={location}
-                            isFavorite={favorites.has(location.naam)}
-                            onToggleFavorite={toggleFavorite}
                             onShowDetails={setSelectedLocation}
                         />
                     ))}
@@ -107,10 +105,7 @@ const LocationsPage = ({ setPageState, initialFilters }) => {
 
             <LocationModal
                 location={selectedLocation}
-                isFavorite={selectedLocation ? favorites.has(selectedLocation.naam) : false}
                 onClose={() => setSelectedLocation(null)}
-                onToggleFavorite={toggleFavorite}
-                onHideLocation={hideLocation}
             />
         </div>
     );

--- a/src/pages/LocationsPage.test.js
+++ b/src/pages/LocationsPage.test.js
@@ -2,13 +2,21 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LocationsPage from './LocationsPage';
 import { locaties } from '../data';
+import { FavoritesProvider } from '../context/FavoritesContext';
+import { HiddenLocationsProvider } from '../context/HiddenLocationsContext';
 
 beforeEach(() => {
     window.localStorage.clear();
 });
 
 test('hidden locations are removed and can be restored', async () => {
-    render(<LocationsPage setPageState={() => {}} initialFilters={[]} />);
+    render(
+        <FavoritesProvider>
+            <HiddenLocationsProvider>
+                <LocationsPage setPageState={() => {}} initialFilters={[]} />
+            </HiddenLocationsProvider>
+        </FavoritesProvider>
+    );
     const name = locaties[0].naam;
 
     // Card should be visible initially
@@ -24,3 +32,4 @@ test('hidden locations are removed and can be restored', async () => {
     userEvent.click(screen.getByText('Verborgen herstellen'));
     expect(await screen.findByText(name)).toBeInTheDocument();
 });
+


### PR DESCRIPTION
## Summary
- add `FavoritesContext` and `HiddenLocationsContext` with providers
- expose hooks that use these contexts
- wrap the app in the providers
- consume contexts directly in components
- update test to use the providers

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688232911ff483249dad324c038b66e9